### PR TITLE
Don't use global i18n instance but create own

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -161,10 +161,7 @@ class View {
     });
 
     let i18nOptions = {lng: lng, fallbackLng: 'en', resources: locales, debug: true}
-    i18next.init(i18nOptions, (err, t) => {
-      // make instance accessable
-      this._map.i18next = i18next;
-
+    this._map.i18next = i18next.createInstance(i18nOptions, (err, t) => {
       L.control.attribution({position: 'topright'}).addTo(this._map);
 
       // add zoom control


### PR DESCRIPTION
Seems there is a race condition during initialization of i18Next if it's
used more than once. Therefor ensure we have our own instance by
creating it and only using this instance.

Fixes #4 