### PR TITLE
View::onDrawingCommit - persist properties

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -458,8 +458,7 @@ class View {
 
       var type = e.layerType,
           layer = e.layer,
-          properties = {};
-
+          properties = filterProperties(layer.options);
 
       // set defaults if it's a marker
       if (layer instanceof L.Marker) {


### PR DESCRIPTION
Polygons and other geometries may end up in missing properties if they
don't have been changed through style editor at least once