### PR TITLE
check for bbox not grid when initializing

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -35,7 +35,7 @@ class View {
 
     // if we have no grid yet, enforce bbox mode so
     // the user is adding one
-    if (!this._grid || this._grid.count() == 0) {
+    if (!this.model.bbox) {
       mode = 'bbox';
     }
 


### PR DESCRIPTION
only maps that have no bbox should force to set a new bbox
grid may be rendered later on