### PR TITLE
Use AktionskartenMarker by default and show tooltip as text

### DIFF
--- a/src/leaflet/editable.js
+++ b/src/leaflet/editable.js
@@ -195,7 +195,10 @@ let MarkerControl = BaseControl.extend({
       title: 'Place a new marker',
     },
     callback(editable) {
-      editable.startMarker().editor.connect();
+      // HACK: Should be handled differntly in StyleEditor...
+      let style = this._map.view._controls.style;
+      let icon = style.getDefaultIcon()
+      editable.startMarker(null, {icon:icon}).editor.connect();
     }
 })
 L.Editable.MarkerEditor.include({

--- a/src/leaflet/styleeditor.css
+++ b/src/leaflet/styleeditor.css
@@ -55,6 +55,17 @@
   margin: 0px 5px;
 }
 
+.label {
+  text-shadow: 1px 1px 2px white, -1px -1px 2px white;
+  font-weight: bold;
+}
+
+.label, .label.leaflet-tooltip-bottom::before  {
+  border: none;
+  box-shadow: none;
+  background: none;
+}
+
 /*
 @keyframes fade {
     to {

--- a/src/leaflet/styleeditor.js
+++ b/src/leaflet/styleeditor.js
@@ -40,7 +40,7 @@ let TooltipContentElement = L.StyleEditor.formElements.FormElement.extend({
       if (tooltip) {
         tooltip.setContent(label)
       } else {
-        marker.bindTooltip(label, {permanent: true, interactive: true})
+        marker.bindTooltip(label, {permanent: true, direction: 'bottom', className: 'label'});
       }
       marker.options = marker.options || {}
       marker.options.label = label

--- a/src/view.js
+++ b/src/view.js
@@ -92,7 +92,7 @@ class View {
           if ('label' in feature.properties) {
             let label = feature.properties.label;
             layer.options.label = label;
-            layer.bindTooltip(label, {permanent: true, interactive: true});
+            layer.bindTooltip(label, {permanent: true, direction: 'bottom', className: 'label'});
           }
 
           let removeHandler = async (e) => {
@@ -156,6 +156,9 @@ class View {
       attributionControl: false,
       editable: true,
     });
+
+    // only needed for Aktionskartenmarker in editable.js
+    this._map.view = this
 
     let i18nOptions = {lng: lng, fallbackLng: 'en', resources: locales, debug: true}
     this._map.i18next = i18next.createInstance(i18nOptions, (err, t) => {


### PR DESCRIPTION
Use AktionskarenMarker by default. As the implementation in StyleEditor/AktionskartenMarker is a bit hacky, we need to do the same by exposing the view to low level components. Otherwise it is not that easy to access the AktionskartenMarker instance.

Additionaly render tooltip text as fixed text (below the feature) as it is done in the final rendering.

Fixes #26
Fixes #27 